### PR TITLE
Fix StringIndexOutOfBoundsException

### DIFF
--- a/calendarview/src/main/java/com/samsistemas/calendarview/widget/CalendarView.java
+++ b/calendarview/src/main/java/com/samsistemas/calendarview/widget/CalendarView.java
@@ -279,7 +279,8 @@ public class CalendarView extends LinearLayout implements ScrollableConst, Touch
         final String[] weekDaysArray = new DateFormatSymbols(getLocale()).getShortWeekdays();
         for (int i = 1; i < weekDaysArray.length; i++) {
             dayOfTheWeekString = weekDaysArray[i];
-            dayOfTheWeekString = dayOfTheWeekString.substring(0, 3).toUpperCase();
+            int length = dayOfTheWeekString.length() < 3 ? dayOfTheWeekString.length() : 3;
+            dayOfTheWeekString = dayOfTheWeekString.substring(0, length).toUpperCase();
             dayOfWeek = (TextView) mView.findViewWithTag(mContext.getString(R.string.day_of_week) + CalendarUtil.getWeekIndex(i, mCalendar));
             dayOfWeek.setText(dayOfTheWeekString);
             dayOfWeek.setTextColor(mDayOfWeekTextColor);


### PR DESCRIPTION
In some locales (e.g. Chinese), the method `getShortWeekdays()` in
`DateFormatSymbols` used in the `CalendarView` class will return an array
of string which are only two characters long.

In this case, `String.substring()` method in the loop, which was
hardcoded with parameter `(0, 3)` will throw a `StringIndexOutOfBoundsException`
since there is only two characters in the returned string.

This commit fixes this behavior by first determining the length of the
string, then use either the length of the string or 3 as the second
parameter to the `substring()` method.